### PR TITLE
feat: extend match schema

### DIFF
--- a/libs/foosball/core/src/lib/enums/match-event-type.enum.ts
+++ b/libs/foosball/core/src/lib/enums/match-event-type.enum.ts
@@ -1,0 +1,3 @@
+export enum MatchEventType {
+  GOAL = 'GOAL',
+}

--- a/libs/foosball/match/src/lib/match.module.ts
+++ b/libs/foosball/match/src/lib/match.module.ts
@@ -1,12 +1,14 @@
 import { DataModule } from '@foosball/data';
+import { PlayerModule } from '@foosball/player';
 import { Module } from '@nestjs/common';
 import { MatchService } from './match.service';
+import { MatchEventResolver } from './resolvers/match-event.resolver';
 import { MatchResolver } from './resolvers/match.resolver';
 
 @Module({
-  imports: [DataModule],
+  imports: [DataModule, PlayerModule],
   controllers: [],
-  providers: [MatchResolver, MatchService],
+  providers: [MatchResolver, MatchEventResolver, MatchService],
   exports: [MatchService],
 })
 export class MatchModule {}

--- a/libs/foosball/match/src/lib/match.service.ts
+++ b/libs/foosball/match/src/lib/match.service.ts
@@ -7,6 +7,7 @@ import { CreateMatchInput } from './dto/create-match.input';
 export class MatchService {
   private readonly matchIncludes = {
     players: true,
+    events: true,
   };
 
   constructor(private readonly data: DataService) {}
@@ -15,10 +16,16 @@ export class MatchService {
     return this.data.match.findMany({ include: this.matchIncludes });
   }
 
-  public findOne(matchWhereUniqueInput: MatchWhereUniqueInput) {
-    return this.data.match.findUnique({
+  public async findOne(matchWhereUniqueInput: MatchWhereUniqueInput) {
+    const found = await this.data.match.findUnique({
       where: matchWhereUniqueInput,
+      include: this.matchIncludes,
     });
+
+    if (!found) {
+      throw new NotFoundException('Match not found');
+    }
+    return found;
   }
 
   public async create(createMatchInput: CreateMatchInput) {

--- a/libs/foosball/match/src/lib/models/match-event.model.ts
+++ b/libs/foosball/match/src/lib/models/match-event.model.ts
@@ -1,0 +1,22 @@
+import { Player } from '@foosball/player';
+import { ObjectType, Field, Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class MatchEvent {
+  @Field(() => Int)
+  id: number;
+
+  matchPlayerId: number;
+
+  @Field()
+  type: string; // to be refactored into enum
+
+  @Field()
+  player: Player; // to be refactored into enum
+
+  @Field(() => Int)
+  order: number;
+
+  @Field()
+  createdAt: Date;
+}

--- a/libs/foosball/match/src/lib/models/match.model.ts
+++ b/libs/foosball/match/src/lib/models/match.model.ts
@@ -1,5 +1,6 @@
 import { Player } from '@foosball/player';
 import { ObjectType, Field, Int } from '@nestjs/graphql';
+import { MatchEvent } from './match-event.model';
 
 @ObjectType()
 export class Match {
@@ -20,6 +21,9 @@ export class Match {
 
   @Field(() => [Player], { nullable: true })
   players?: Player;
+
+  @Field(() => [MatchEvent], { nullable: true })
+  events?: MatchEvent;
 
   @Field()
   createdAt: Date;

--- a/libs/foosball/match/src/lib/resolvers/match-event.resolver.ts
+++ b/libs/foosball/match/src/lib/resolvers/match-event.resolver.ts
@@ -1,0 +1,13 @@
+import { Player, PlayerService } from '@foosball/player';
+import { Context, ResolveField, Resolver, Root } from '@nestjs/graphql';
+import { MatchEvent } from '../models/match-event.model';
+
+@Resolver(() => MatchEvent)
+export class MatchEventResolver {
+  constructor(private readonly playerService: PlayerService) {}
+
+  @ResolveField()
+  async player(@Root() matchEvent: MatchEvent, @Context() ctx): Promise<Player> {
+    return this.playerService.findOne({ id: matchEvent.matchPlayerId });
+  }
+}

--- a/libs/foosball/match/src/lib/resolvers/match.resolver.ts
+++ b/libs/foosball/match/src/lib/resolvers/match.resolver.ts
@@ -2,24 +2,28 @@ import { Resolver, Query, Mutation, Args, Int, ResolveField, Context, Root } fro
 import { MatchService as MatchService } from '../match.service';
 import { CreateMatchInput } from '../dto/create-match.input';
 import { Match } from '../models/match.model';
+import { DataService } from '@foosball/data';
+import { Player } from '@foosball/player';
 
 @Resolver(() => Match)
 export class MatchResolver {
-  constructor(private readonly matchService: MatchService) {}
+  constructor(private readonly data: DataService, private readonly matchService: MatchService) {}
 
-  // @ResolveField()
-  // async players(@Root() match: Match, @Context() ctx): Promise<Player[]> {
-  //   const playersInMatch = await this.prismaService.playersInMatches.findMany({
-  //     where: {
-  //       matchId: match.id,
-  //     },
-  //     include: {
-  //       player: true,
-  //     },
-  //   });
+  @ResolveField()
+  async players(@Root() match: Match, @Context() ctx): Promise<Player[]> {
+    // NOTE: actually we don't want to use this.data in a resolver directly
+    // In search for a better solution
+    const playersInMatch = await this.data.playersInMatches.findMany({
+      where: {
+        matchId: match.id,
+      },
+      include: {
+        player: true,
+      },
+    });
 
-  //   return playersInMatch.map((playerInMatch) => playerInMatch.player);
-  // }
+    return playersInMatch.map(playerInMatch => playerInMatch.player);
+  }
 
   @Mutation(() => Match)
   createMatch(@Args('createMatchInput') createMatchInput: CreateMatchInput) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,7 +67,7 @@ model MatchEvent {
   matchPlayer   Player   @relation(fields: [matchPlayerId], references: [id])
   type          String // Enum: goal, klinker.. to be defined
   order         Int      @default(0)
-  args          String? // Enum: goal, klinker.. to be defined
+  args          String? // JSON
   createdAt     DateTime @default(now())
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,8 @@ model Player {
   stats   PlayerStats[]
 
   // one-to-many relations
-  matches PlayersInMatches[]
+  matches     PlayersInMatches[]
+  matchEvents MatchEvent[]
 }
 
 model PlayerStats {
@@ -55,6 +56,19 @@ model Match {
   createdAt DateTime           @default(now())
   updatedAt DateTime           @default(now())
   players   PlayersInMatches[]
+  events    MatchEvent[]
+}
+
+model MatchEvent {
+  id            Int      @id @default(autoincrement())
+  matchId       Int
+  matchPlayerId Int
+  match         Match    @relation(fields: [matchId], references: [id])
+  matchPlayer   Player   @relation(fields: [matchPlayerId], references: [id])
+  type          String // Enum: goal, klinker.. to be defined
+  order         Int      @default(0)
+  args          String? // Enum: goal, klinker.. to be defined
+  createdAt     DateTime @default(now())
 }
 
 model PlayersInMatches {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -20,7 +20,7 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
+  .catch(e => {
     throw e;
   })
   .finally(async () => {
@@ -28,10 +28,10 @@ main()
   });
 
 async function seedPlayers() {
-  const createManyPosts = getPlayers().map((player) =>
+  const createManyPosts = getPlayers().map(player =>
     prisma.player.create({
       data: player,
-    }),
+    })
   );
 
   await prisma.playersInMatches.deleteMany();
@@ -46,12 +46,12 @@ async function seedPlayers() {
 
 async function seedMatches() {
   const players = await prisma.player.findMany();
-  const playerIds = players.map((player) => player.id);
+  const playerIds = players.map(player => player.id);
 
-  const createManyItems = getMatches(playerIds, 5).map((match) =>
+  const createManyItems = getMatches(playerIds, 5).map(match =>
     prisma.match.create({
       data: match,
-    }),
+    })
   );
 
   // Seed players
@@ -70,8 +70,7 @@ function getPlayers() {
           slackId: 'U1234',
           twitterHandle: 'mschilling',
           githubHandle: 'mschilling',
-
-        }
+        },
       },
       stats: {
         create: {
@@ -79,8 +78,7 @@ function getPlayers() {
           totalLosses: 0,
           highestWinStreak: 5,
           highestLoseStreak: 0,
-
-        }
+        },
       },
     },
     { name: 'Cas', email: 'cvandinter@move4mobile.com' },
@@ -129,6 +127,14 @@ function createRandomMatch(playerIds: number[]) {
         {
           playerId: playerId4,
           side: 'AWAY',
+        },
+      ],
+    },
+    events: {
+      create: [
+        {
+          matchPlayerId: playerId1,
+          type: 'GOAL',
         },
       ],
     },


### PR DESCRIPTION
* resolve match players
* add MatchEvent entity to schema

Example output:

```
{
  "data": {
    "match": {
      "id": 1,
      "status": "FINISHED",
      "date": "2021-12-12T13:43:17.238Z",
      "homeScore": 3,
      "awayScore": 8,
      "players": [
        {
          "id": 1,
          "name": "P1",
          "email": "p1@example.com"
        },
        {
          "id": 4,
          "name": "P2",
          "email": "p2@example.com"
        },
        {
          "id": 8,
          "name": "P3",
          "email": "p3@example.com"
        },
        {
          "id": 10,
          "name": "P4",
          "email": "p4@example.com"
        }
      ],
      "createdAt": "2021-12-12T13:43:17.238Z",
      "updatedAt": "2021-12-12T13:43:17.238Z",
      "events": [
            {
              "id": 1,
              "type": "GOAL",
              "player": {
                "name": "P1"
              },
              "order": 0,
              "createdAt": "2021-12-12T13:43:17.238Z"
            }
          ]
    }
  }
}
```