### PR TITLE
fix: Gamify cascading delete

### DIFF
--- a/apps/gamify/web-app/src/app/pages/admin/applications/applications.component.ts
+++ b/apps/gamify/web-app/src/app/pages/admin/applications/applications.component.ts
@@ -28,7 +28,7 @@ export class ApplicationsComponent implements OnInit {
       width: '400px',
       data: {
         title: 'Delete application',
-        message: 'Are you sure you want to delete this application?',
+        message: 'Are you sure you want to delete this application? This will permanently delete all associated data, e.g. players, badges, etc.',
       }
     });
 

--- a/apps/gamify/web-app/src/app/shared/components/application-details-badges/application-details-badges.component.ts
+++ b/apps/gamify/web-app/src/app/shared/components/application-details-badges/application-details-badges.component.ts
@@ -166,7 +166,7 @@ export class ApplicationDetailsBadgesComponent implements OnInit {
       width: '400px',
       data: {
         title: 'Delete badge',
-        message: 'Are you sure you want to delete this badge?',
+        message: 'Are you sure you want to delete this badge? Every user who obtained this badge will lose it.',
       }
     });
 

--- a/libs/gamify/data/prisma/schema.prisma
+++ b/libs/gamify/data/prisma/schema.prisma
@@ -38,7 +38,7 @@ model Badge {
     id                   Int         @id @default(autoincrement())
     createdAt            DateTime    @default(now())
     name                 String
-    application          Application @relation(fields: [applicationId], references: [id])
+    application          Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
     applicationId        Int
     iconPath             String?
     tier                 String
@@ -48,9 +48,9 @@ model Badge {
 }
 
 model ApplicationUser {
-    application   Application @relation(fields: [applicationId], references: [id])
+    application   Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
     applicationId Int
-    user          User        @relation(fields: [userId], references: [id])
+    user          User        @relation(fields: [userId], references: [id], onDelete: Cascade)
     userId        Int
     joinedAt      DateTime    @default(now())
 
@@ -59,9 +59,9 @@ model ApplicationUser {
 
 model UserBadge {
     id       Int      @id @default(autoincrement())
-    user     User     @relation(fields: [userId], references: [id])
+    user     User     @relation(fields: [userId], references: [id], onDelete: Cascade)
     userId   Int
-    badge    Badge    @relation(fields: [badgeId], references: [id])
+    badge    Badge    @relation(fields: [badgeId], references: [id], onDelete: Cascade)
     badgeId  Int
     earnedAt DateTime @default(now())
 }


### PR DESCRIPTION
When deleting a badge that had users the API threw an internal server error because of foreing key constraints. The same happened when deleting an application that had badges or users.

Fix: add cascade delete on references to applications and badges. Improve warning messages when deleting badges or applications.